### PR TITLE
Add git config test for installation

### DIFF
--- a/tests/test-install.py
+++ b/tests/test-install.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from subprocess import Popen, PIPE
+
 
 class TestInstallation(unittest.TestCase):
 
@@ -13,6 +15,14 @@ class TestInstallation(unittest.TestCase):
                         '.git-templates directory not found')
         self.assertIn('sailr.sh', os.readlink(os.path.join(self.home, '.git-templates/hooks/commit-msg')),
                       'git hook must point to sailr.sh')
+
+    def test_git_config(self):
+        process = Popen(['git', 'config', 'init.templatedir'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        output, err = process.communicate('')
+        return_code = process.returncode
+        self.assertEqual(output, b'~/.git-templates\n')
+        self.assertEqual(err, b'')
+        self.assertEqual(return_code, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Do we assume that all the users use bash? The newly added test may fail otherwise. :thinking:
I can add Travis-CI config to test the code and the unit tests against different setups.